### PR TITLE
Introduced railway.json 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn nametrackerapi.wsgi
+web: gunicorn nametrackerapi.wsgi:application

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "build": {
+    "command": "python manage.py collectstatic --noinput"
+  },
+  "release": {
+    "command": "python manage.py migrate"
+  },
+  "start": {
+    "command": "gunicorn nametrackerapi.wsgi:application"
+  }
+}


### PR DESCRIPTION
This move is necessary as it allows migrations to auto-deploy, instead of the manual way I have been using.